### PR TITLE
Support trams/light rails in RKRP (Rejseplanen) profile

### DIFF
--- a/pyhafas/profile/rkrp/__init__.py
+++ b/pyhafas/profile/rkrp/__init__.py
@@ -50,7 +50,7 @@ class RKRPProfile(BaseProfile):
         'bus': [32],  # BUS
         'ferry': [64],  # F
         'subway': [128],  # U
-        'tram': [256],  # T
+        'tram': [256, 2048],  # T
         'taxi': [512]  # Group Taxi
     }
 

--- a/pyhafas/profile/rkrp/__init__.py
+++ b/pyhafas/profile/rkrp/__init__.py
@@ -49,7 +49,7 @@ class RKRPProfile(BaseProfile):
         'suburban': [16],  # S
         'bus': [32],  # BUS
         'ferry': [64],  # F
-        'subway': [128],  # U
+        'subway': [128,1024],  # U
         'tram': [256, 2048],  # T
         'taxi': [512]  # Group Taxi
     }


### PR DESCRIPTION
## Description

Adds support for an additional transport mode in the RKRP profile.

This allows showing connections using the light rail/tram (called "letbane" in Danish).

_FYI: I also made #57 for adding RKRP to the Profiles page in docs_

### Preview

Here is an example of a connection that didn't show up before:

![Screenshot 2025-02-13 at 22 55 25](https://github.com/user-attachments/assets/465a7b2e-9a62-4474-b9da-89b7781b6600)
