### PR TITLE
Add RKRP profile to docs

### DIFF
--- a/docs/usage/profiles.rst
+++ b/docs/usage/profiles.rst
@@ -168,3 +168,38 @@ other-bus             sonstige Busse
 Default Products
 ^^^^^^^^^^^^^^^^
 All available products specified above are enabled by default.
+
+Rejsekort & Rejseplan (RKRP)
+-----------------------------
+Usage
+^^^^^^
+.. code:: python
+
+  from pyhafas.profile import RKRPProfile
+  client = HafasClient(RKRPProfile())
+
+Available Products
+^^^^^^^^^^^^^^^^^^
+
+===================== ==================
+pyHaFAS Internal Name Example Train Type
+===================== ==================
+long_distance_express ICE
+long_distance         IC/EC
+regional_express      RE/IR
+regional              RB
+suburban              S
+bus                   BUS
+ferry                 F
+subway                U
+tram                  T
+taxi                  Group Taxi
+===================== ==================
+
+Default Products
+^^^^^^^^^^^^^^^^
+All available products specified above are enabled by default.
+
+Other interesting Stuff
+^^^^^^^^^^^^^^^^^^^^^^^
+* Official API documentation: `<https://help.rejseplanen.dk/hc/da/articles/214174465-Rejseplanens-API>`_

--- a/docs/usage/profiles.rst
+++ b/docs/usage/profiles.rst
@@ -202,4 +202,4 @@ All available products specified above are enabled by default.
 
 Other interesting Stuff
 ^^^^^^^^^^^^^^^^^^^^^^^
-* Official API documentation: `<https://help.rejseplanen.dk/hc/da/articles/214174465-Rejseplanens-API>`_
+* Official API documentation: `<https://labs.rejseplanen.dk/hc/da/articles/21554723926557-Om-API-2-0>`_


### PR DESCRIPTION
## Description

Adds the RKRP profile to https://pyhafas.readthedocs.io/en/stable/usage/profiles.html


### Preview

![Screenshot 2025-02-13 at 23 15 02](https://github.com/user-attachments/assets/8ee4ca14-2285-4fa7-b267-ba8d4092ac24)
